### PR TITLE
Add a verbose parameter to disable the warning messages in the console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Webstorm project config folder
+.idea

--- a/examples/debug/src/App.tsx
+++ b/examples/debug/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
     <Canvas shadows>
       <OrbitControls makeDefault />
       <PerspectiveCamera position={[-5, 5, 5]} makeDefault />
-      <Environment preset="warehouse" />
+      <Environment files="https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/empty_warehouse_01_1k.hdr" />
       <Thing />
       {/* <CacheTest /> */}
 

--- a/examples/instances/src/App.js
+++ b/examples/instances/src/App.js
@@ -115,7 +115,7 @@ function App() {
         }}
       >
         <Suspense>
-          <Environment preset="sunset" />
+          <Environment files="https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/venice_sunset_1k.hdr" />
           <Thing />
         </Suspense>
 

--- a/examples/points/src/App.js
+++ b/examples/points/src/App.js
@@ -95,7 +95,7 @@ function App() {
         }}
       >
         <Suspense>
-          <Environment preset="sunset" />
+          <Environment files="https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/venice_sunset_1k.hdr" />
           <Thing />
         </Suspense>
 

--- a/examples/waves/src/App.tsx
+++ b/examples/waves/src/App.tsx
@@ -60,7 +60,7 @@ export default function App() {
         <color attach="background" args={['#ebebeb']} />
         <Suspense fallback={null}>
           {['MeshPhysicalMaterial', 'MeshStanderedMaterial'].includes(Base.name) ? (
-            <Environment preset="sunset" />
+            <Environment files="https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/venice_sunset_1k.hdr" />
           ) : (
             <Lights />
           )}

--- a/package/README.md
+++ b/package/README.md
@@ -45,6 +45,7 @@ function Box() {
     baseMaterial: THREE.MeshPhysicalMaterial,
     vertexShader: /* glsl */ ` ... `,
     fragmentShader: /* glsl */ ` ... `,
+    silent: true, // Disables the default warning if true
     uniforms: {
       uTime: {
         value: 0,
@@ -83,6 +84,8 @@ function Cube() {
         baseMaterial={THREE.MeshPhysicalMaterial}
         vertexShader={/* glsl */ ` ... `}
         fragmentShader={/* glsl */ ` ... `}
+        {/*silent parameter to true disables the default warning if needed*/}
+        silent
         uniforms={{
           uTime: {
             value: 0,

--- a/package/src/keywords.ts
+++ b/package/src/keywords.ts
@@ -11,5 +11,5 @@ export default {
   metalness: 'csm_Metalness', // Metalness
   emissive: 'csm_Emissive', // Emissive
   ao: 'csm_AO', // AO
-  bump: 'csm_Bump' // Bump
+  bump: 'csm_Bump', // Bump
 }

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -30,7 +30,7 @@ export interface iCSMInternals<T extends MaterialConstructor> {
   instanceID: string
   type: string
   isAlreadyExtended: boolean
-  cacheHash: string,
+  cacheHash: string
   silent?: boolean
 }
 

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -15,6 +15,7 @@ export type iCSMParams<T extends MaterialConstructor> = {
   fragmentShader?: string
   cacheKey?: () => string
   patchMap?: iCSMPatchMap
+  verbose?: boolean
   uniforms?: { [key: string]: THREE.IUniform<any> }
 } & (MaterialParams<T> extends undefined ? {} : MaterialParams<T>)
 
@@ -29,7 +30,8 @@ export interface iCSMInternals<T extends MaterialConstructor> {
   instanceID: string
   type: string
   isAlreadyExtended: boolean
-  cacheHash: string
+  cacheHash: string,
+  verbose: boolean
 }
 
 export type Uniform = { [key: string]: THREE.IUniform<any> }

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -15,7 +15,7 @@ export type iCSMParams<T extends MaterialConstructor> = {
   fragmentShader?: string
   cacheKey?: () => string
   patchMap?: iCSMPatchMap
-  verbose?: boolean
+  silent?: boolean
   uniforms?: { [key: string]: THREE.IUniform<any> }
 } & (MaterialParams<T> extends undefined ? {} : MaterialParams<T>)
 
@@ -31,7 +31,7 @@ export interface iCSMInternals<T extends MaterialConstructor> {
   type: string
   isAlreadyExtended: boolean
   cacheHash: string,
-  verbose: boolean
+  silent?: boolean
 }
 
 export type Uniform = { [key: string]: THREE.IUniform<any> }

--- a/package/src/vanilla.ts
+++ b/package/src/vanilla.ts
@@ -99,15 +99,15 @@ export default class CustomShaderMaterial<
   private __csm: iCSMInternals<T>
 
   constructor({
-                baseMaterial, //
-                fragmentShader,
-                vertexShader,
-                uniforms,
-                patchMap,
-                cacheKey,
-                silent,
-                ...opts
-              }: iCSMParams<T>) {
+    baseMaterial, //
+    fragmentShader,
+    vertexShader,
+    uniforms,
+    patchMap,
+    cacheKey,
+    silent,
+    ...opts
+  }: iCSMParams<T>) {
     let base: THREE.Material
     if (isConstructor(baseMaterial)) {
       // If base material is a constructor, instantiate it

--- a/package/src/vanilla.ts
+++ b/package/src/vanilla.ts
@@ -47,7 +47,7 @@ function isConstructor<T extends MaterialConstructor>(f: T | InstanceType<T>): f
   return true
 }
 
-function copyObject(target: any, source: any, verbose = true) {
+function copyObject(target: any, source: any, silent = false) {
   Object.assign(target, source)
 
   const proto = Object.getPrototypeOf(source)
@@ -63,7 +63,7 @@ function copyObject(target: any, source: any, verbose = true) {
     .forEach((val) => {
       // If function exists on target, rename it with "base_" prefix
       if (typeof target[val[0]] === 'function') {
-        if (verbose) console.warn(`Function ${val[0]} already exists on CSM, renaming to base_${val[0]}`)
+        if (!silent) console.warn(`Function ${val[0]} already exists on CSM, renaming to base_${val[0]}`)
         const baseName = `base_${val[0]}`
         target[baseName] = val[1].value.bind(target)
         return
@@ -105,7 +105,7 @@ export default class CustomShaderMaterial<
                 uniforms,
                 patchMap,
                 cacheKey,
-                verbose,
+                silent,
                 ...opts
               }: iCSMParams<T>) {
     let base: THREE.Material
@@ -128,7 +128,7 @@ export default class CustomShaderMaterial<
     // Copy all properties from base material onto this material
     // Rename any functions that already exist on this material with "base_" prefix
     super()
-    copyObject(this, base, verbose)
+    copyObject(this, base, silent)
 
     // Set up private internals
     this.__csm = {
@@ -141,7 +141,7 @@ export default class CustomShaderMaterial<
       type: base.type,
       isAlreadyExtended: !isFunctionEmpty(base.onBeforeCompile),
       cacheHash: ``,
-      verbose: verbose === undefined ? true : verbose,
+      silent: silent,
     }
 
     this.uniforms = {
@@ -198,7 +198,7 @@ export default class CustomShaderMaterial<
       fragmentShader: this.__csm.fragmentShader,
       vertexShader: this.__csm.vertexShader,
       uniforms: this.uniforms,
-      verbose: this.__csm.verbose,
+      silent: this.__csm.silent,
       patchMap: this.__csm.patchMap,
       cacheKey: this.__csm.cacheKey,
     }


### PR DESCRIPTION
I suggested a `verbose` parameter sometime ago, I had some time today, so I made it myself. 

I preserved the default behaviour of warning, so it is working as before. But we have now the possibility to disable the warnings, if it is polluting.

Resolves #37 